### PR TITLE
リクエストのメソッドが不正の場合に対応を追加

### DIFF
--- a/lib/handler-utils.js
+++ b/lib/handler-utils.js
@@ -18,8 +18,8 @@ function handleLogout(req, res) {
 
 /**
  * 404 Not Found を返す
- * @param {http.IncomingMessage} req 
- * @param {http.ServerResponse} res 
+ * @param {http.IncomingMessage} req
+ * @param {http.ServerResponse} res
  */
 function handleNotFound(req, res) {
   res.writeHead(404, {
@@ -29,7 +29,20 @@ function handleNotFound(req, res) {
   res.end();
 }
 
+/**
+ * 400 Bad Requestを返す
+ * @param {http.IncomingMessage} req
+ * @param {http.ServerResponse} res
+ */
+function handleBadRequest(req, res) {
+  res.writeHead(400, {
+    'Content-Type': 'text/html; charset=utf-8',
+  });
+  res.end('400 Bad Request');
+}
+
 module.exports = {
   handleLogout,
   handleNotFound,
+  handleBadRequest,
 };

--- a/lib/posts-handler.js
+++ b/lib/posts-handler.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const pug = require('pug');
+const utils = require('./handler-utils');
 const Post = require('./post');
 /**
  * /posts のリクエストをGETとPOSTに振り分ける
@@ -41,6 +42,7 @@ function handle(req, res) {
         });
       break;
     default:
+      utils.handleBadRequest(req, res);
       break;
   }
 }


### PR DESCRIPTION
## 実装

- lib/handler-utils.js 400 Bad Request を送出する関数
- lib/posts-handler.js req.methodがGETとPOST以外は400 Bad Request を返す