### PR TITLE
トラッキングCookieの実装

### DIFF
--- a/lib/posts-handler.js
+++ b/lib/posts-handler.js
@@ -3,12 +3,18 @@
 
 const pug = require('pug');
 const Post = require('./post');
+const Cookies = require('cookies');
+const trackingIdKey = 'tracking_id';
+
 /**
  * /posts のリクエストをGETとPOSTに振り分ける
  * @param {http.IncomingMessage} req リクエスト
  * @param {http.ServerResponse} res レスポンス
  */
 function handle(req, res) {
+  // Cookieの付与
+  const cookies = new Cookies(req, res);
+  addTrackingCookie(cookies);
   switch (req.method) {
     case 'GET':
       res.writeHead(200, {
@@ -42,6 +48,18 @@ function handle(req, res) {
       break;
     default:
       break;
+  }
+}
+
+/**
+ * トラッキングCookieの付与
+ * @param {Cookies} cookies
+ */
+function addTrackingCookie(cookies) {
+  if (!cookies.get(trackingIdKey)) {
+    const trackingId = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
+    const tomorrow = new Date(Date.now() + 1000 * 60 * 60 * 24);
+    cookies.set(trackingIdKey, trackingId, { expires: tomorrow });
   }
 }
 

--- a/lib/posts-handler.js
+++ b/lib/posts-handler.js
@@ -39,7 +39,7 @@ function handle(req, res) {
           // データベースに保存
           Post.create({
             content: content,
-            trackingCookie: null,
+            trackingCookie: cookies.get(trackingIdKey),
             postedBy: req.user,
           }).then(() => {
             handleRedirectPosts(req, res);
@@ -56,6 +56,7 @@ function handle(req, res) {
  * @param {Cookies} cookies
  */
 function addTrackingCookie(cookies) {
+  // Coockieが取得できない場合のみ新しいCookieをセットする
   if (!cookies.get(trackingIdKey)) {
     const trackingId = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
     const tomorrow = new Date(Date.now() + 1000 * 60 * 60 * 24);

--- a/lib/posts-handler.js
+++ b/lib/posts-handler.js
@@ -24,6 +24,12 @@ function handle(req, res) {
       Post.findAll({ order: [['id', 'DESC']] }).then((posts) => {
         res.end(pug.renderFile('./views/posts.pug', { posts: posts }));
       });
+      console.info(
+        `閲覧がありました: user: ${req.user}, ` +
+          `trackingId: ${cookies.get(trackingIdKey)}, ` +
+          `remoteAddless: ${req.socket.remoteAddress}, ` +
+          `UserAgent: ${req.headers['user-agent']}`
+      );
       break;
     case 'POST':
       let buffer = [];

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "node test.js"
   },
   "dependencies": {
+    "cookies": "0.5.1",
     "http-auth": "3.2.3",
     "pg": "7.17.1",
     "pg-hstore": "2.3.3",

--- a/views/posts.pug
+++ b/views/posts.pug
@@ -16,6 +16,7 @@ html(lang="ja")
         button(type="submit") 投稿
     h2 投稿一覧
     each post in posts
+      h3 #{post.id} ID: #{post.trackingCookie}
       p #{post.content}
       p 投稿日時 #{post.createdAt}
       hr

--- a/yarn.lock
+++ b/yarn.lock
@@ -167,6 +167,13 @@ constantinople@^3.0.1, constantinople@^3.1.2:
     babel-types "^6.26.0"
     babylon "^6.18.0"
 
+cookies@0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/cookies/-/cookies-0.5.1.tgz#2560c304fe8f8cbd002e08b9599d2e7479d37298"
+  integrity sha1-JWDDBP6PjL0ALgi5WZ0udHnTcpg=
+  dependencies:
+    keygrip "~1.0.0"
+
 core-js@^2.4.0:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
@@ -295,6 +302,11 @@ jstransformer@1.0.0:
   dependencies:
     is-promise "^2.0.0"
     promise "^7.0.1"
+
+keygrip@~1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/keygrip/-/keygrip-1.0.3.tgz#399d709f0aed2bab0a059e0cdd3a5023a053e1dc"
+  integrity sha512-/PpesirAIfaklxUzp4Yb7xBper9MwP6hNRA6BGGUFCgbJ+BM5CKBtsoxinNXkLHAr+GXS1/lSlF2rP7cv5Fl+g==
 
 kind-of@^3.0.2:
   version "3.2.2"


### PR DESCRIPTION
## 実装

- npm install cookies
- lib/posts-handlers.js Cookieの生成、投稿時の保存、表示のための値を渡す
- lib/posts-handers.js 閲覧ログ
- views/posts.pug Cookieの値をIDとして表示