### PR TITLE
削除機能の実装

### DIFF
--- a/lib/posts-handler.js
+++ b/lib/posts-handler.js
@@ -62,6 +62,16 @@ function handle(req, res) {
 }
 
 /**
+ * 指定されたidの投稿を削除する
+ * @param {http.IncomingMessage} req 
+ * @param {http.ServerResponse} res 
+ */
+function handleDelete(req, res) {
+  console.log('handleDelete', req.user);
+  handleRedirectPosts(req, res);
+}
+
+/**
  * トラッキングCookieの付与
  * @param {Cookies} cookies
  */
@@ -74,6 +84,7 @@ function addTrackingCookie(cookies) {
   }
 }
 
+
 function handleRedirectPosts(req, res) {
   res.writeHead(303, {
     Location: '/posts',
@@ -83,4 +94,5 @@ function handleRedirectPosts(req, res) {
 
 module.exports = {
   handle,
+  handleDelete
 };

--- a/lib/posts-handler.js
+++ b/lib/posts-handler.js
@@ -23,7 +23,9 @@ function handle(req, res) {
       });
       // データベースから読み込み
       Post.findAll({ order: [['id', 'DESC']] }).then((posts) => {
-        res.end(pug.renderFile('./views/posts.pug', { posts: posts }));
+        res.end(
+          pug.renderFile('./views/posts.pug', { posts: posts, user: req.user })
+        );
       });
       console.info(
         `閲覧がありました: user: ${req.user}, ` +

--- a/lib/posts-handler.js
+++ b/lib/posts-handler.js
@@ -63,12 +63,43 @@ function handle(req, res) {
 
 /**
  * 指定されたidの投稿を削除する
- * @param {http.IncomingMessage} req 
- * @param {http.ServerResponse} res 
+ * @param {http.IncomingMessage} req
+ * @param {http.ServerResponse} res
  */
 function handleDelete(req, res) {
-  console.log('handleDelete', req.user);
-  handleRedirectPosts(req, res);
+  switch (req.method) {
+    case 'POST':
+      const buffer = [];
+      req
+        .on('data', (chunk) => {
+          // chunkを受け取る
+          buffer.push(chunk);
+        })
+        .on('end', () => {
+          const body = Buffer.concat(buffer).toString();
+          const decoded = decodeURIComponent(body);
+          const postedId = decoded.split(/id=/)[1];
+          // 該当の投稿IDのデータをデータベースから探す
+          Post.findByPk(postedId).then((post) => {
+            // 認可
+            if (req.user === post.postedBy) {
+              // 削除する
+              post.destroy().then(() => {
+                console.info(
+                  `削除されました: user: ${req.user}, ` +
+                    `remoteAddress: ${req.connection.remoteAddress}, ` +
+                    `userAgent: ${req.headers['user-agent']} `
+                );
+                handleRedirectPosts(req, res);
+              });
+            }
+          });
+        });
+      break;
+    default:
+      utils.handleBadRequest(req, res);
+      break;
+  }
 }
 
 /**
@@ -84,7 +115,6 @@ function addTrackingCookie(cookies) {
   }
 }
 
-
 function handleRedirectPosts(req, res) {
   res.writeHead(303, {
     Location: '/posts',
@@ -94,5 +124,5 @@ function handleRedirectPosts(req, res) {
 
 module.exports = {
   handle,
-  handleDelete
+  handleDelete,
 };

--- a/lib/router.js
+++ b/lib/router.js
@@ -17,11 +17,16 @@ function route(req, res) {
     case '/logout':
       utils.handleLogout(req, res);
       break;
+    case '/posts?delete=1':
+      // 削除
+      postsHandler.handleDelete(req, res);
+      break;
     case '/':
+      // ルートのアクセスは投稿一覧へリダイレクト
       res.writeHead(308, {
-        'Location': '/posts'
+        Location: '/posts',
       });
-      res.end()
+      res.end();
       break;
     default:
       utils.handleNotFound(req, res);

--- a/views/posts.pug
+++ b/views/posts.pug
@@ -22,6 +22,6 @@ html(lang="ja")
       - var isDeletable = (user === post.postedBy)
       if isDeletable 
         form(action="/posts?delete=1", method="post") 
-          input(type="hidden" name="id" vallue=post.id)
+          input(type="hidden" name="id" value=post.id)
           button(type="submit") 削除
       hr

--- a/views/posts.pug
+++ b/views/posts.pug
@@ -19,4 +19,9 @@ html(lang="ja")
       h3 #{post.id} ID: #{post.trackingCookie}
       p #{post.content}
       p 投稿日時 #{post.createdAt}
+      - var isDeletable = (user === post.postedBy)
+      if isDeletable 
+        form(action="/posts?delete=1", method="post") 
+          input(type="hidden" name="id" vallue=post.id)
+          button(type="submit") 削除
       hr


### PR DESCRIPTION
## 実装内容

- views/posts.pug 削除ボタンの追加
    - リクエストしてきたユーザーと投稿に保存しているデータが同一の場合に削除ボタンを表示する
    - 自分の投稿はいつでも消せるようにするため
- lib/router.js 投稿削除のルーティングを追加
    -  /post?delete=1 で投稿をデータベースから削除
    -   HTMLのフォームはDELETEを扱えないためPOSTで代用する
- lib/posts-handler.js /post?delete=1 で飛んできてPOSTメソッドの場合は削除実行する
    - データベースからの削除は物理削除
    - POSTメソッド以外の場合は不正リクエスト(Bad Request)として処理