### PR TITLE
管理者機能の実装

### DIFF
--- a/lib/posts-handler.js
+++ b/lib/posts-handler.js
@@ -82,7 +82,7 @@ function handleDelete(req, res) {
           // 該当の投稿IDのデータをデータベースから探す
           Post.findByPk(postedId).then((post) => {
             // 認可
-            if (req.user === post.postedBy) {
+            if (req.user === post.postedBy || req.user === 'admin') {
               // 削除する
               post.destroy().then(() => {
                 console.info(

--- a/lib/posts-handler.js
+++ b/lib/posts-handler.js
@@ -23,6 +23,9 @@ function handle(req, res) {
       });
       // データベースから読み込み
       Post.findAll({ order: [['id', 'DESC']] }).then((posts) => {
+        posts.forEach((post) => {
+          post.content = post.content.replace(/\n/g, '<br>');
+        });
         res.end(
           pug.renderFile('./views/posts.pug', { posts: posts, user: req.user })
         );

--- a/views/posts.pug
+++ b/views/posts.pug
@@ -21,7 +21,7 @@ html(lang="ja")
         h3 #{post.id} : 管理人★
       else 
         h3 #{post.id} ID: #{post.trackingCookie}
-      p #{post.content}
+      p!= post.content
       p 投稿日時 #{post.createdAt}
       - var isAdmin = (user === 'admin')
       if isAdmin 

--- a/views/posts.pug
+++ b/views/posts.pug
@@ -16,7 +16,11 @@ html(lang="ja")
         button(type="submit") 投稿
     h2 投稿一覧
     each post in posts
-      h3 #{post.id} ID: #{post.trackingCookie}
+      - var isPostedAdmin = (post.postedBy === 'admin')
+      if isPostedAdmin 
+        h3 #{post.id} : 管理人★
+      else 
+        h3 #{post.id} ID: #{post.trackingCookie}
       p #{post.content}
       p 投稿日時 #{post.createdAt}
       - var isDeletable = (user === post.postedBy)

--- a/views/posts.pug
+++ b/views/posts.pug
@@ -23,6 +23,9 @@ html(lang="ja")
         h3 #{post.id} ID: #{post.trackingCookie}
       p #{post.content}
       p 投稿日時 #{post.createdAt}
+      - var isAdmin = (user === 'admin')
+      if isAdmin 
+        p 投稿者 #{post.postedBy}
       - var isDeletable = (user === post.postedBy)
       if isDeletable 
         form(action="/posts?delete=1", method="post") 

--- a/views/posts.pug
+++ b/views/posts.pug
@@ -26,7 +26,7 @@ html(lang="ja")
       - var isAdmin = (user === 'admin')
       if isAdmin 
         p 投稿者 #{post.postedBy}
-      - var isDeletable = (user === post.postedBy)
+      - var isDeletable = (user === post.postedBy || isAdmin)
       if isDeletable 
         form(action="/posts?delete=1", method="post") 
           input(type="hidden" name="id" value=post.id)


### PR DESCRIPTION
## 実装内容

一般ユーザーと管理者の差別化として以下の機能を管理者権限ユーザーの機能として実装
1. 管理人の投稿だとわかる（ID欄に管理人と表記する）
   - views/posts.pug  (postedBy==='admin')で管理人と一般ユーザーを区別する
 
2. 管理人は全ての投稿を削除可能
   - views/posts.pug  削除ボタンの表示条件に(user === 'admin') を追加
   - lib/posts-handler.js データベース削除の認可に (req.user === 'admin') を追加

3. 管理人は投稿がどのアカウントからされているか一覧から確認できる
   - views/posts.pug  (user === 'admin') の場合のみ postedBy の表示

