### PR TITLE
CSRF脆弱性の対応

### DIFF
--- a/lib/posts-handler.js
+++ b/lib/posts-handler.js
@@ -113,22 +113,33 @@ function handleDelete(req, res) {
         .on('end', () => {
           const body = Buffer.concat(buffer).toString();
           const decoded = decodeURIComponent(body);
-          const postedId = decoded.split(/id=/)[1];
-          // 該当の投稿IDのデータをデータベースから探す
-          Post.findByPk(postedId).then((post) => {
-            // 認可
-            if (req.user === post.postedBy || req.user === 'admin') {
-              // 削除する
-              post.destroy().then(() => {
-                console.info(
-                  `削除されました: user: ${req.user}, ` +
-                    `remoteAddress: ${req.connection.remoteAddress}, ` +
-                    `userAgent: ${req.headers['user-agent']} `
-                );
-                handleRedirectPosts(req, res);
-              });
-            }
-          });
+          const query = decoded.match(/id=(.*)&oneTimeToken=(.*)/);
+          if (!query) {
+            utils.handleBadRequest(req, res)
+            return;
+          }
+          const postedId = query[1];
+          const token = query[2];
+          if (token === oneTimeTokenMap.get(req.user)) {
+            // 該当の投稿IDのデータをデータベースから探す
+            Post.findByPk(postedId).then((post) => {
+              // 認可
+              if (req.user === post.postedBy || req.user === 'admin') {
+                // 削除する
+                post.destroy().then(() => {
+                  console.info(
+                    `削除されました: user: ${req.user}, ` +
+                      `remoteAddress: ${req.connection.remoteAddress}, ` +
+                      `userAgent: ${req.headers['user-agent']} `
+                  );
+                  oneTimeTokenMap.delete(req.user);
+                  handleRedirectPosts(req, res);
+                });
+              }
+            });
+          } else {
+            utils.handleBadRequest(req, res);
+          }
         });
       break;
     default:

--- a/lib/posts-handler.js
+++ b/lib/posts-handler.js
@@ -8,7 +8,8 @@ const Post = require('./post');
 const Cookies = require('cookies');
 const moment = require('moment-timezone');
 const trackingIdKey = 'tracking_id';
-
+// ワンタイムトークンを保持する キー：ユーザー名、値：トークン
+const oneTimeTokenMap = new Map();
 /**
  * /posts のリクエストをGETとPOSTに振り分ける
  * @param {http.IncomingMessage} req リクエスト
@@ -31,8 +32,15 @@ function handle(req, res) {
             .tz('Asia/Tokyo')
             .format('YYYY年MM月DD日 HH時mm分ss秒');
         });
+        // ワンタイムトークンの生成
+        const oneTimeToken = crypto.randomBytes(8).toString('hex');
+        oneTimeTokenMap.set(req.user, oneTimeToken);
         res.end(
-          pug.renderFile('./views/posts.pug', { posts: posts, user: req.user })
+          pug.renderFile('./views/posts.pug', {
+            posts: posts,
+            user: req.user,
+            oneTimeToken: oneTimeToken,
+          })
         );
       });
       console.info(
@@ -42,6 +50,7 @@ function handle(req, res) {
           `UserAgent: ${req.headers['user-agent']}`
       );
       break;
+
     case 'POST':
       let buffer = [];
       req
@@ -51,16 +60,34 @@ function handle(req, res) {
         .on('end', () => {
           const body = Buffer.concat(buffer).toString();
           const decoded = decodeURIComponent(body);
-          const content = decoded.split(/content=/)[1];
-          console.info(`投稿されました: ${content}`);
-          // データベースに保存
-          Post.create({
-            content: content,
-            trackingCookie: trackingId,
-            postedBy: req.user,
-          }).then(() => {
+          const query = decoded.match(/content=(.*)&oneTimeToken=(.*)/);
+          if (!query) {
+            utils.handleBadRequest(req, res);
+            return;
+          }
+          const content = query[1];
+          const token = query[2];
+          // 何も書いてない場合は何もしない
+          if (!content) {
             handleRedirectPosts(req, res);
-          });
+            return;
+          }
+          // ワンタイムトークンの検証
+          if (token === oneTimeTokenMap.get(req.user)) {
+            console.info(`投稿されました: ${content}`);
+            // データベースに保存
+            Post.create({
+              content: content,
+              trackingCookie: trackingId,
+              postedBy: req.user,
+            }).then(() => {
+              // ワンタイムトークンの削除
+              oneTimeTokenMap.delete(req.user);
+              handleRedirectPosts(req, res);
+            });
+          } else {
+            utils.handleBadRequest(req, res);
+          }
         });
       break;
     default:

--- a/views/posts.pug
+++ b/views/posts.pug
@@ -19,6 +19,7 @@ html(lang="ja")
     form(action="/posts", method="post") 
       div.form-group
         textarea(name="content",rows="4").form-control
+        input(type="hidden" name="oneTimeToken" value=oneTimeToken)
       div.form-group 
         button(type="submit").btn.btn-primary 投稿
     h2 投稿一覧

--- a/views/posts.pug
+++ b/views/posts.pug
@@ -43,6 +43,7 @@ html(lang="ja")
           if isDeletable 
             form(action="/posts?delete=1", method="post") 
               input(type="hidden" name="id" value=post.id)
+              input(type="hidden" name="oneTimeToken" value=oneTimeToken)
               button(type="submit").btn.btn-danger.float-right 削除
 
     //- jQuery


### PR DESCRIPTION
## 実装内容

- lib/posts-handler.js
    - ワンタイムトークンを保存するMap
    - GETメソッドの時にワンタイムトークンを生成してフォームに埋め込む
    - ワンタイムトークンは一覧を読み込み直すたびに新しいものが生成される
    - POSTメソッドの時にクエリで渡されたトークンと保存しているトークンを確認して同じなら投稿を認可する
    - 削除の場合も同じ
    - 空白の投稿の時は投稿を実行しない機能を実装

- views/posts.pug
    - 投稿ボタンと削除ボタンにワンタイムトークンをhidden属性で埋め込む